### PR TITLE
add as_format_jpg and fix if_not_found bug

### DIFF
--- a/label_studio/io_storages/aperturedb/form_layout.yml
+++ b/label_studio/io_storages/aperturedb/form_layout.yml
@@ -39,6 +39,9 @@ ImportStorage:
         label: Image Constraints (optional)
         description: ApertureDB FindImage constraints (see https://docs.aperturedata.io/query_language/Reference/shared_command_parameters/constraints)
       - type: toggle
+        name: as_format_jpg
+        label: Conversion Images to JPEG
+      - type: toggle
         name: predictions
         label: Include Bounding Box Predictions
       - type: textarea

--- a/label_studio/io_storages/aperturedb/form_layout.yml
+++ b/label_studio/io_storages/aperturedb/form_layout.yml
@@ -40,7 +40,7 @@ ImportStorage:
         description: ApertureDB FindImage constraints (see https://docs.aperturedata.io/query_language/Reference/shared_command_parameters/constraints)
       - type: toggle
         name: as_format_jpg
-        label: Conversion Images to JPEG
+        label: Convert Images to JPEG
       - type: toggle
         name: predictions
         label: Include Bounding Box Predictions

--- a/label_studio/io_storages/migrations/0017_aperturedb.py
+++ b/label_studio/io_storages/migrations/0017_aperturedb.py
@@ -62,6 +62,7 @@ class Migration(migrations.Migration):
                 ('use_ssl', models.BooleanField(default=True, help_text='Use SSL when communicating with ApertureDB', verbose_name='use_ssl')),
                 ('limit', models.PositiveIntegerField(blank=True, help_text='Maximum number of tasks', null=True, verbose_name='limit')),
                 ('constraints', models.TextField(blank=True, help_text='ApertureDB FindImage constraints (see https://docs.aperturedata.io/query_language/Reference/shared_command_parameters/constraints)', null=True, verbose_name='constraints')),
+                ('as_format_jpg', models.BooleanField(default=False, help_text='Convert images to JPEG format', verbose_name='as_format_jpg')),
                 ('predictions', models.BooleanField(default=False, help_text='Load bounding box predictions from ApertureDB?', verbose_name='predictions')),
                 ('pred_constraints', models.TextField(blank=True, help_text='ApertureDB constraints on bounding box predictions (see https://docs.aperturedata.io/query_language/Reference/shared_command_parameters/constraints)', null=True, verbose_name='constraints')),
                 ('project', models.ForeignKey(help_text='A unique integer value identifying this project.', on_delete=django.db.models.deletion.CASCADE, related_name='io_storages_aperturedbimportstorages', to='projects.project')),


### PR DESCRIPTION
Two changes:
* Add new flag for converting images to JPEG format.  This is useful if the customer is storing images as TIFF.
* Fixes bug with `if_not_found` that broke demo

Note: When setting up import of images in TIFF format, the default constraint won't work because they don't have width and height.  
![image](https://github.com/aperture-data/label-studio/assets/31326650/c55cf198-a373-4d92-95e7-86a96164c4c3)