### PR TITLE
Phase 1 fix for demo problem

### DIFF
--- a/label_studio/io_storages/aperturedb/form_layout.yml
+++ b/label_studio/io_storages/aperturedb/form_layout.yml
@@ -10,6 +10,7 @@ adb_host_config: &adb_host_config
   - type: number
     name: port
     label: Port
+    value: 55555
   - type: text
     name: username
     label: User Name
@@ -34,7 +35,7 @@ ImportStorage:
     fields: *adb_host_config
   - columnCount: 1
     fields:
-      - type: textarea
+      - type: json
         name: constraints
         label: Image Constraints (optional)
         description: ApertureDB FindImage constraints (see https://docs.aperturedata.io/query_language/Reference/shared_command_parameters/constraints)
@@ -44,10 +45,16 @@ ImportStorage:
       - type: toggle
         name: predictions
         label: Include Bounding Box Predictions
-      - type: textarea
+      - type: json
         name: pred_constraints
         label: Prediction Constraints (optional)
         description: ApertureDB constraints on bounding box predictions (see https://docs.aperturedata.io/query_language/Reference/shared_command_parameters/constraints)
+      - type: number
+        name: limit
+        label: Limit (optional)
+        description: Maximum number of images to import
+        value: 1000
+        min: 1
 
 ExportStorage:
   - columnCount: 3


### PR DESCRIPTION
The LabelStudio demo has been failing recently, primarily because there are too many images to import before "sync" hits the timeout.  (This is apparently a problem shared by many LS storage integrators.)

This is a short term fix that adds a `limit` parameter, default 1000, to limit the maximum number of images to synchronize with LS tasks.

This fix also fixes a long-standing problem whereby adding explicit constraints overrides the internal restrictions that the images have `width` and `height` properties.  This is required in order to translate between LS percentage co-ordinates and ADB pixel co-ordinates.

This fix also adds a default value of 55555 for the ApertureDB port number. 

This fix leaves some outstanding problems that will potentially be the target of future work, including:
* Performance enhancements to allow more images to be synchronized in one go.  
* Incremental synchronization so that each request brings in `limit` **more** images.
* Editing of existing bounding boxes without creating duplicates.  This may require enhancements to the ApertureDB query language.
* Doing without explicit `width` and `height` properties.  This may require enhancements to the ApertureDB query language.
* Locking of predicted bounding boxes so that the user cannot edit them.
* Sorting out why only some existing bounding boxes are imported to LS.  This may be related to the use of labels not defined in the LS annotation settings.