### PR TITLE
Pin third-party actions

### DIFF
--- a/.github/workflows/algolia-crawler.yml
+++ b/.github/workflows/algolia-crawler.yml
@@ -32,4 +32,4 @@ jobs:
     steps:
       - name: Algolia Docsearch Action
         id: algolia
-        uses:  adapttive/algolia-docsearch-action@1.1.1
+        uses:  adapttive/algolia-docsearch-action@91bbd6823e2865fcab2fa6b617afb7204e236678

--- a/.github/workflows/algolia-crawler.yml
+++ b/.github/workflows/algolia-crawler.yml
@@ -32,4 +32,4 @@ jobs:
     steps:
       - name: Algolia Docsearch Action
         id: algolia
-        uses:  adapttive/algolia-docsearch-action@1.1.1
+        uses:  adapttive/algolia-docsearch-action@91bbd6823e2865fcab2fa6b617afb7204e236678  # Pinned to release 1.1.1

--- a/.github/workflows/algolia-crawler.yml
+++ b/.github/workflows/algolia-crawler.yml
@@ -32,4 +32,4 @@ jobs:
     steps:
       - name: Algolia Docsearch Action
         id: algolia
-        uses:  adapttive/algolia-docsearch-action@91bbd6823e2865fcab2fa6b617afb7204e236678
+        uses:  adapttive/algolia-docsearch-action@1.1.1

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820 # v3.0.0
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/blue.yml
+++ b/.github/workflows/blue.yml
@@ -22,6 +22,6 @@ jobs:
         with:
           python-version: '3.10'
 
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd
         with:
           extra_args: blue --all-files --hook-stage pre-push

--- a/.github/workflows/blue.yml
+++ b/.github/workflows/blue.yml
@@ -22,6 +22,6 @@ jobs:
         with:
           python-version: '3.10'
 
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # Pinned to release v3.0.1
         with:
           extra_args: blue --all-files --hook-stage pre-push

--- a/.github/workflows/blue.yml
+++ b/.github/workflows/blue.yml
@@ -22,6 +22,6 @@ jobs:
         with:
           python-version: '3.10'
 
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd
+      - uses: pre-commit/action@v3.0.1
         with:
           extra_args: blue --all-files --hook-stage pre-push

--- a/.github/workflows/build_pypi.yml
+++ b/.github/workflows/build_pypi.yml
@@ -58,7 +58,7 @@ jobs:
       pipy-artifact-url: ${{ steps.pypi-package-details.outputs.pipy-artifact-url }}
       pipy-artifact-digests-sha256: ${{ steps.pypi-package-details.outputs.pipy-artifact-digests-sha256 }}
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820 # v3.0.0
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -102,7 +102,7 @@ jobs:
           python-version: '3.10'
 
       - name: Set up Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
 
       - name: Install Python dependencies
         run: poetry install --with build

--- a/.github/workflows/bump-helm-chart.yml
+++ b/.github/workflows/bump-helm-chart.yml
@@ -23,7 +23,7 @@ jobs:
     name: "Bump Helm Chart"
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Configure git
         shell: bash

--- a/.github/workflows/bump-helm-chart.yml
+++ b/.github/workflows/bump-helm-chart.yml
@@ -23,7 +23,7 @@ jobs:
     name: "Bump Helm Chart"
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Configure git
         shell: bash

--- a/.github/workflows/bump-helm-chart.yml
+++ b/.github/workflows/bump-helm-chart.yml
@@ -23,7 +23,7 @@ jobs:
     name: "Bump Helm Chart"
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Configure git
         shell: bash

--- a/.github/workflows/cancel_cicd_pipeline.yml
+++ b/.github/workflows/cancel_cicd_pipeline.yml
@@ -17,5 +17,5 @@ jobs:
   cancel:
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
       - run: echo CI/CD Pipeline-${{ github.event.pull_request.number || github.event.pull_request.head.ref || github.ref_name }}

--- a/.github/workflows/cancel_cicd_pipeline.yml
+++ b/.github/workflows/cancel_cicd_pipeline.yml
@@ -17,5 +17,5 @@ jobs:
   cancel:
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
       - run: echo CI/CD Pipeline-${{ github.event.pull_request.number || github.event.pull_request.head.ref || github.ref_name }}

--- a/.github/workflows/cancel_cicd_pipeline.yml
+++ b/.github/workflows/cancel_cicd_pipeline.yml
@@ -17,5 +17,5 @@ jobs:
   cancel:
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
       - run: echo CI/CD Pipeline-${{ github.event.pull_request.number || github.event.pull_request.head.ref || github.ref_name }}

--- a/.github/workflows/cicd_pipeline.yml
+++ b/.github/workflows/cicd_pipeline.yml
@@ -33,7 +33,7 @@ jobs:
       commit-message: ${{ steps.commit-details.outputs.commit-message }}
     timeout-minutes: 25
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Checkout
         if: github.event_name == 'push'
@@ -41,7 +41,7 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         id: changes
         with:
           filters: |
@@ -222,7 +222,7 @@ jobs:
       id: ${{ steps.update-draft-release.outputs.id }}
       rc-version: ${{ steps.create-draft-release.outputs.rc-version }}
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/cicd_pipeline.yml
+++ b/.github/workflows/cicd_pipeline.yml
@@ -33,7 +33,7 @@ jobs:
       commit-message: ${{ steps.commit-details.outputs.commit-message }}
     timeout-minutes: 25
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Checkout
         if: github.event_name == 'push'
@@ -41,7 +41,7 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # Pinned to release v3
         id: changes
         with:
           filters: |
@@ -222,7 +222,7 @@ jobs:
       id: ${{ steps.update-draft-release.outputs.id }}
       rc-version: ${{ steps.create-draft-release.outputs.rc-version }}
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/cicd_pipeline.yml
+++ b/.github/workflows/cicd_pipeline.yml
@@ -33,7 +33,7 @@ jobs:
       commit-message: ${{ steps.commit-details.outputs.commit-message }}
     timeout-minutes: 25
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Checkout
         if: github.event_name == 'push'
@@ -41,7 +41,7 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
+      - uses: dorny/paths-filter@v3
         id: changes
         with:
           filters: |
@@ -222,7 +222,7 @@ jobs:
       id: ${{ steps.update-draft-release.outputs.id }}
       rc-version: ${{ steps.create-draft-release.outputs.rc-version }}
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Codespell
-        uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630
+        uses: codespell-project/actions-codespell@v2
         with:
           skip: "**/3rdpartylicenses.txt,**/package.json,**/package-lock.json"

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Codespell
-        uses: codespell-project/actions-codespell@v2
+        uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630  # Pinned to release v2
         with:
           skip: "**/3rdpartylicenses.txt,**/package.json,**/package-lock.json"

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Codespell
-        uses: codespell-project/actions-codespell@v2
+        uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630
         with:
           skip: "**/3rdpartylicenses.txt,**/package.json,**/package-lock.json"

--- a/.github/workflows/delete_pr_branch.yml
+++ b/.github/workflows/delete_pr_branch.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Delete branch
         uses: actions/github-script@v7

--- a/.github/workflows/delete_pr_branch.yml
+++ b/.github/workflows/delete_pr_branch.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Delete branch
         uses: actions/github-script@v7

--- a/.github/workflows/delete_pr_branch.yml
+++ b/.github/workflows/delete_pr_branch.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Delete branch
         uses: actions/github-script@v7

--- a/.github/workflows/docker-build-ontop.yml
+++ b/.github/workflows/docker-build-ontop.yml
@@ -48,7 +48,7 @@ jobs:
     timeout-minutes: 90
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Check user's membership
         uses: actions/github-script@v7

--- a/.github/workflows/docker-build-ontop.yml
+++ b/.github/workflows/docker-build-ontop.yml
@@ -48,7 +48,7 @@ jobs:
     timeout-minutes: 90
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Check user's membership
         uses: actions/github-script@v7

--- a/.github/workflows/docker-build-ontop.yml
+++ b/.github/workflows/docker-build-ontop.yml
@@ -48,7 +48,7 @@ jobs:
     timeout-minutes: 90
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Check user's membership
         uses: actions/github-script@v7

--- a/.github/workflows/docker-build-ubi.yml
+++ b/.github/workflows/docker-build-ubi.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Check user's membership
         uses: actions/github-script@v7

--- a/.github/workflows/docker-build-ubi.yml
+++ b/.github/workflows/docker-build-ubi.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Check user's membership
         uses: actions/github-script@v7

--- a/.github/workflows/docker-build-ubi.yml
+++ b/.github/workflows/docker-build-ubi.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 45
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Check user's membership
         uses: actions/github-script@v7

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -31,7 +31,7 @@ jobs:
       image_version: ${{ steps.version.outputs.image_version }}
       build_version: ${{ steps.version.outputs.build_version }}
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Check user's membership
         uses: actions/github-script@v7
@@ -177,7 +177,7 @@ jobs:
           GITHUB_RUN_ID: "${{ github.run_id }}"
           GITHUB_SHA: "${{ github.sha }}"
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_LSE_BOT_TOKEN }}
-        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e
+        uses: slackapi/slack-github-action@v1.26
         with:
           channel-id: 'C01RJV08UJK'
           payload: "{\"text\": \":alert:<!subteam^${{ vars.SLACK_GR_DEVOPS }}>\\n*Branch: ${{ inputs.branch_name }}*\\n*Build status: <https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}|FAILED>*\\n*Commit: <https://github.com/${{ env.GITHUB_REPOSITORY }}/commit/${{ steps.version.outputs.sha }}|${{ steps.version.outputs.sha }}>*\"}"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -31,7 +31,7 @@ jobs:
       image_version: ${{ steps.version.outputs.image_version }}
       build_version: ${{ steps.version.outputs.build_version }}
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Check user's membership
         uses: actions/github-script@v7
@@ -177,7 +177,7 @@ jobs:
           GITHUB_RUN_ID: "${{ github.run_id }}"
           GITHUB_SHA: "${{ github.sha }}"
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_LSE_BOT_TOKEN }}
-        uses: slackapi/slack-github-action@v1.26
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e
         with:
           channel-id: 'C01RJV08UJK'
           payload: "{\"text\": \":alert:<!subteam^${{ vars.SLACK_GR_DEVOPS }}>\\n*Branch: ${{ inputs.branch_name }}*\\n*Build status: <https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}|FAILED>*\\n*Commit: <https://github.com/${{ env.GITHUB_REPOSITORY }}/commit/${{ steps.version.outputs.sha }}|${{ steps.version.outputs.sha }}>*\"}"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -31,7 +31,7 @@ jobs:
       image_version: ${{ steps.version.outputs.image_version }}
       build_version: ${{ steps.version.outputs.build_version }}
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Check user's membership
         uses: actions/github-script@v7
@@ -177,7 +177,7 @@ jobs:
           GITHUB_RUN_ID: "${{ github.run_id }}"
           GITHUB_SHA: "${{ github.sha }}"
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_LSE_BOT_TOKEN }}
-        uses: slackapi/slack-github-action@v1.26
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e  # Pinned to release v1.26
         with:
           channel-id: 'C01RJV08UJK'
           payload: "{\"text\": \":alert:<!subteam^${{ vars.SLACK_GR_DEVOPS }}>\\n*Branch: ${{ inputs.branch_name }}*\\n*Build status: <https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}|FAILED>*\\n*Commit: <https://github.com/${{ env.GITHUB_REPOSITORY }}/commit/${{ steps.version.outputs.sha }}|${{ steps.version.outputs.sha }}>*\"}"

--- a/.github/workflows/docker-command.yml
+++ b/.github/workflows/docker-command.yml
@@ -15,10 +15,10 @@ jobs:
     outputs:
       error-msg: ${{ steps.check-membership.outputs.error }}
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Add Workflow link to command comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -93,7 +93,7 @@ jobs:
           esac
 
       - name: Add reaction to command comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -108,7 +108,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Update comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/docker-command.yml
+++ b/.github/workflows/docker-command.yml
@@ -15,10 +15,10 @@ jobs:
     outputs:
       error-msg: ${{ steps.check-membership.outputs.error }}
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Add Workflow link to command comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # Pinned to release v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -93,7 +93,7 @@ jobs:
           esac
 
       - name: Add reaction to command comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # Pinned to release v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -108,7 +108,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Update comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # Pinned to release v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/docker-command.yml
+++ b/.github/workflows/docker-command.yml
@@ -15,10 +15,10 @@ jobs:
     outputs:
       error-msg: ${{ steps.check-membership.outputs.error }}
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Add Workflow link to command comment
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -93,7 +93,7 @@ jobs:
           esac
 
       - name: Add reaction to command comment
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -108,7 +108,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Update comment
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/docker-release-promote.yml
+++ b/.github/workflows/docker-release-promote.yml
@@ -29,7 +29,7 @@ jobs:
     outputs:
       image_version: ${{ steps.get_info.outputs.image_version }}
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Get an artifact from check suite
         uses: actions/github-script@v7
@@ -227,7 +227,7 @@ jobs:
           docker run -v ${{ github.workspace }}:/workspace:rw -u root --rm ${{ env.IMAGE_NAME }}:${{ inputs.release_tag }} cp -r /label-studio/web/dist/ /workspace/web/
 
       - name: Create Sentry release @ backend
-        uses: getsentry/action-release@a74facf8a080ecbdf1cb355f16743530d712abb7
+        uses: getsentry/action-release@v1
         continue-on-error: true
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -237,7 +237,7 @@ jobs:
           projects: opensource-v1-backend
 
       - name: Create Sentry release @ frontend
-        uses: getsentry/action-release@a74facf8a080ecbdf1cb355f16743530d712abb7
+        uses: getsentry/action-release@v1
         continue-on-error: true
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/docker-release-promote.yml
+++ b/.github/workflows/docker-release-promote.yml
@@ -29,7 +29,7 @@ jobs:
     outputs:
       image_version: ${{ steps.get_info.outputs.image_version }}
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Get an artifact from check suite
         uses: actions/github-script@v7
@@ -227,7 +227,7 @@ jobs:
           docker run -v ${{ github.workspace }}:/workspace:rw -u root --rm ${{ env.IMAGE_NAME }}:${{ inputs.release_tag }} cp -r /label-studio/web/dist/ /workspace/web/
 
       - name: Create Sentry release @ backend
-        uses: getsentry/action-release@v1
+        uses: getsentry/action-release@a74facf8a080ecbdf1cb355f16743530d712abb7  # Pinned to release v1
         continue-on-error: true
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -237,7 +237,7 @@ jobs:
           projects: opensource-v1-backend
 
       - name: Create Sentry release @ frontend
-        uses: getsentry/action-release@v1
+        uses: getsentry/action-release@a74facf8a080ecbdf1cb355f16743530d712abb7  # Pinned to release v1
         continue-on-error: true
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/docker-release-promote.yml
+++ b/.github/workflows/docker-release-promote.yml
@@ -29,7 +29,7 @@ jobs:
     outputs:
       image_version: ${{ steps.get_info.outputs.image_version }}
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Get an artifact from check suite
         uses: actions/github-script@v7
@@ -227,7 +227,7 @@ jobs:
           docker run -v ${{ github.workspace }}:/workspace:rw -u root --rm ${{ env.IMAGE_NAME }}:${{ inputs.release_tag }} cp -r /label-studio/web/dist/ /workspace/web/
 
       - name: Create Sentry release @ backend
-        uses: getsentry/action-release@v1
+        uses: getsentry/action-release@a74facf8a080ecbdf1cb355f16743530d712abb7
         continue-on-error: true
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -237,7 +237,7 @@ jobs:
           projects: opensource-v1-backend
 
       - name: Create Sentry release @ frontend
-        uses: getsentry/action-release@v1
+        uses: getsentry/action-release@a74facf8a080ecbdf1cb355f16743530d712abb7
         continue-on-error: true
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/feature-flags-update.yml
+++ b/.github/workflows/feature-flags-update.yml
@@ -27,7 +27,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Configure git
         shell: bash

--- a/.github/workflows/feature-flags-update.yml
+++ b/.github/workflows/feature-flags-update.yml
@@ -27,7 +27,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Configure git
         shell: bash

--- a/.github/workflows/feature-flags-update.yml
+++ b/.github/workflows/feature-flags-update.yml
@@ -27,7 +27,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Configure git
         shell: bash

--- a/.github/workflows/ff-command.yml
+++ b/.github/workflows/ff-command.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Update comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -55,7 +55,7 @@ jobs:
           echo "reaction=${reaction}" >> $GITHUB_OUTPUT
 
       - name: Update comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -68,7 +68,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Update comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/ff-command.yml
+++ b/.github/workflows/ff-command.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Update comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # Pinned to release v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -55,7 +55,7 @@ jobs:
           echo "reaction=${reaction}" >> $GITHUB_OUTPUT
 
       - name: Update comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # Pinned to release v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -68,7 +68,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Update comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # Pinned to release v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/ff-command.yml
+++ b/.github/workflows/ff-command.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Update comment
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -55,7 +55,7 @@ jobs:
           echo "reaction=${reaction}" >> $GITHUB_OUTPUT
 
       - name: Update comment
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -68,7 +68,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Update comment
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/follow-merge-lsf-sync-schedule.yml
+++ b/.github/workflows/follow-merge-lsf-sync-schedule.yml
@@ -10,7 +10,7 @@ jobs:
   dispatch:
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Create dispatch event
         uses: actions/github-script@v7

--- a/.github/workflows/follow-merge-lsf-sync-schedule.yml
+++ b/.github/workflows/follow-merge-lsf-sync-schedule.yml
@@ -10,7 +10,7 @@ jobs:
   dispatch:
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Create dispatch event
         uses: actions/github-script@v7

--- a/.github/workflows/follow-merge-lsf-sync-schedule.yml
+++ b/.github/workflows/follow-merge-lsf-sync-schedule.yml
@@ -10,7 +10,7 @@ jobs:
   dispatch:
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Create dispatch event
         uses: actions/github-script@v7

--- a/.github/workflows/follow-merge-sync-pr.yml
+++ b/.github/workflows/follow-merge-sync-pr.yml
@@ -29,7 +29,7 @@ jobs:
     if: startsWith(github.head_ref, 'fb-')
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Check user's membership
         uses: actions/github-script@v7

--- a/.github/workflows/follow-merge-sync-pr.yml
+++ b/.github/workflows/follow-merge-sync-pr.yml
@@ -29,7 +29,7 @@ jobs:
     if: startsWith(github.head_ref, 'fb-')
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Check user's membership
         uses: actions/github-script@v7

--- a/.github/workflows/follow-merge-sync-pr.yml
+++ b/.github/workflows/follow-merge-sync-pr.yml
@@ -29,7 +29,7 @@ jobs:
     if: startsWith(github.head_ref, 'fb-')
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Check user's membership
         uses: actions/github-script@v7

--- a/.github/workflows/follow-merge-upstream-repo-sync.yml
+++ b/.github/workflows/follow-merge-upstream-repo-sync.yml
@@ -23,7 +23,7 @@ jobs:
       github.event.client_payload.event_action == 'merged'
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Details
         id: details
@@ -181,7 +181,7 @@ jobs:
 
       - name: "Poetry: Set up"
         if: steps.details.outputs.poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a
 
       - name: "Poetry: Commit and Push"
         if: steps.details.outputs.poetry
@@ -438,7 +438,7 @@ jobs:
       github.event.client_payload.event_action == 'closed'
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Get PR
         uses: actions/github-script@v7

--- a/.github/workflows/follow-merge-upstream-repo-sync.yml
+++ b/.github/workflows/follow-merge-upstream-repo-sync.yml
@@ -23,7 +23,7 @@ jobs:
       github.event.client_payload.event_action == 'merged'
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Details
         id: details
@@ -181,7 +181,7 @@ jobs:
 
       - name: "Poetry: Set up"
         if: steps.details.outputs.poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a  # Pinned to release v1
 
       - name: "Poetry: Commit and Push"
         if: steps.details.outputs.poetry
@@ -438,7 +438,7 @@ jobs:
       github.event.client_payload.event_action == 'closed'
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Get PR
         uses: actions/github-script@v7

--- a/.github/workflows/follow-merge-upstream-repo-sync.yml
+++ b/.github/workflows/follow-merge-upstream-repo-sync.yml
@@ -23,7 +23,7 @@ jobs:
       github.event.client_payload.event_action == 'merged'
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Details
         id: details
@@ -181,7 +181,7 @@ jobs:
 
       - name: "Poetry: Set up"
         if: steps.details.outputs.poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a
+        uses: snok/install-poetry@v1
 
       - name: "Poetry: Commit and Push"
         if: steps.details.outputs.poetry
@@ -438,7 +438,7 @@ jobs:
       github.event.client_payload.event_action == 'closed'
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Get PR
         uses: actions/github-script@v7

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -53,7 +53,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Configure git
         shell: bash

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -53,7 +53,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Configure git
         shell: bash

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -53,7 +53,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Configure git
         shell: bash

--- a/.github/workflows/frontend-command.yml
+++ b/.github/workflows/frontend-command.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Add Workflow link to command comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # Pinned to release v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -95,7 +95,7 @@ jobs:
 
       - name: Add reaction to command comment on nothing to do
         if: steps.commit_and_push.outputs.changes == 'no'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # Pinned to release v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -106,7 +106,7 @@ jobs:
 
       - name: Add reaction to command comment on success
         if: steps.commit_and_push.outputs.changes != 'no'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # Pinned to release v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -117,7 +117,7 @@ jobs:
           reactions: "+1"
 
       - name: Add reaction to command comment on failure
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # Pinned to release v4
         if: failure()
         with:
           token: ${{ secrets.GIT_PAT }}
@@ -133,7 +133,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Update comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # Pinned to release v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/frontend-command.yml
+++ b/.github/workflows/frontend-command.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Add Workflow link to command comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -95,7 +95,7 @@ jobs:
 
       - name: Add reaction to command comment on nothing to do
         if: steps.commit_and_push.outputs.changes == 'no'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -106,7 +106,7 @@ jobs:
 
       - name: Add reaction to command comment on success
         if: steps.commit_and_push.outputs.changes != 'no'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -117,7 +117,7 @@ jobs:
           reactions: "+1"
 
       - name: Add reaction to command comment on failure
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         if: failure()
         with:
           token: ${{ secrets.GIT_PAT }}
@@ -133,7 +133,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Update comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/frontend-command.yml
+++ b/.github/workflows/frontend-command.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Add Workflow link to command comment
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -95,7 +95,7 @@ jobs:
 
       - name: Add reaction to command comment on nothing to do
         if: steps.commit_and_push.outputs.changes == 'no'
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -106,7 +106,7 @@ jobs:
 
       - name: Add reaction to command comment on success
         if: steps.commit_and_push.outputs.changes != 'no'
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -117,7 +117,7 @@ jobs:
           reactions: "+1"
 
       - name: Add reaction to command comment on failure
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        uses: peter-evans/create-or-update-comment@v4
         if: failure()
         with:
           token: ${{ secrets.GIT_PAT }}
@@ -133,7 +133,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Update comment
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/git-command.yml
+++ b/.github/workflows/git-command.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Add Workflow link to command comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # Pinned to release v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -60,7 +60,7 @@ jobs:
         uses: ./.github/actions-hub/actions/git-push
 
       - name: Add reaction to command comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # Pinned to release v4
         if: always()
         with:
           token: ${{ secrets.GIT_PAT }}
@@ -76,7 +76,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Update comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # Pinned to release v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/git-command.yml
+++ b/.github/workflows/git-command.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Add Workflow link to command comment
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -60,7 +60,7 @@ jobs:
         uses: ./.github/actions-hub/actions/git-push
 
       - name: Add reaction to command comment
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        uses: peter-evans/create-or-update-comment@v4
         if: always()
         with:
           token: ${{ secrets.GIT_PAT }}
@@ -76,7 +76,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Update comment
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/git-command.yml
+++ b/.github/workflows/git-command.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Add Workflow link to command comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -60,7 +60,7 @@ jobs:
         uses: ./.github/actions-hub/actions/git-push
 
       - name: Add reaction to command comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         if: always()
         with:
           token: ${{ secrets.GIT_PAT }}
@@ -76,7 +76,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Update comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -19,7 +19,7 @@ jobs:
     name: "Gitleaks"
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Configure gitleaks binary cache
         id: cache

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -19,7 +19,7 @@ jobs:
     name: "Gitleaks"
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Configure gitleaks binary cache
         id: cache

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -19,7 +19,7 @@ jobs:
     name: "Gitleaks"
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Configure gitleaks binary cache
         id: cache

--- a/.github/workflows/help-command.yml
+++ b/.github/workflows/help-command.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Update comment if empty
         if: ${{ github.event.client_payload.slash_command.args.all == '' }}
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/invite-check.yml
+++ b/.github/workflows/invite-check.yml
@@ -18,7 +18,7 @@ jobs:
           ! grep --only-matching --extended-regexp '(&quot;|")isSharedInviteError(&quot;|")\s*:\s*true' <(curl --silent --location --user-agent Chrome/65536.0.0.0 ${{ env.INVITE_LINK }})
       - name: Notify to Slack
         if: always() && steps.invite_link_is_active.outcome == 'failure'
-        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e
+        uses: slackapi/slack-github-action@v1.26
         with:
           channel-id: '${{ secrets.SLACK_LS_MONITORING_CHANNEL }}'
           slack-message: "Our <${{ env.INVITE_LINK }}|public invite link> has expired and needs to be manually updated:\n1. <https://slack.com/intl/en-es/help/articles/201330256-Invite-new-members-to-your-workspace#share-an-invite-link|Generate a new link> without expiry date; you may need to deactivate the previous one first.\n2. Update the permanent redirect link <https://s3.console.aws.amazon.com/s3/bucket/slack.labelstud.io/property/website/edit?region=us-east-1|on the S3 dashboard> with newly generated link WITHOUT URL SCHEME."
@@ -36,7 +36,7 @@ jobs:
 #          )
 #      - name: Notify to Slack
 #        if: always() && steps.invite_link_has_teamdomains.outcome == 'failure'
-#        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e
+#        uses: slackapi/slack-github-action@v1.26
 #        with:
 #          channel-id: '${{ secrets.SLACK_LS_MONITORING_CHANNEL }}'
 #          slack-message: "Our <${{ env.INVITE_LINK }}|public invite link> was configured to allow signups only from a list of allowed domains:\n1. Go to <https://label-studio.slack.com/admin/settings|Workspace settings>, next to `Joining This Workspace`, click `Expand`.\n2. Delete all domains from the list, select `Allow invitations` and click `Save`."

--- a/.github/workflows/invite-check.yml
+++ b/.github/workflows/invite-check.yml
@@ -18,7 +18,7 @@ jobs:
           ! grep --only-matching --extended-regexp '(&quot;|")isSharedInviteError(&quot;|")\s*:\s*true' <(curl --silent --location --user-agent Chrome/65536.0.0.0 ${{ env.INVITE_LINK }})
       - name: Notify to Slack
         if: always() && steps.invite_link_is_active.outcome == 'failure'
-        uses: slackapi/slack-github-action@v1.26
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e  # Pinned to release v1.26
         with:
           channel-id: '${{ secrets.SLACK_LS_MONITORING_CHANNEL }}'
           slack-message: "Our <${{ env.INVITE_LINK }}|public invite link> has expired and needs to be manually updated:\n1. <https://slack.com/intl/en-es/help/articles/201330256-Invite-new-members-to-your-workspace#share-an-invite-link|Generate a new link> without expiry date; you may need to deactivate the previous one first.\n2. Update the permanent redirect link <https://s3.console.aws.amazon.com/s3/bucket/slack.labelstud.io/property/website/edit?region=us-east-1|on the S3 dashboard> with newly generated link WITHOUT URL SCHEME."
@@ -36,7 +36,7 @@ jobs:
 #          )
 #      - name: Notify to Slack
 #        if: always() && steps.invite_link_has_teamdomains.outcome == 'failure'
-#        uses: slackapi/slack-github-action@v1.26
+#        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e  # Pinned to release v1.26
 #        with:
 #          channel-id: '${{ secrets.SLACK_LS_MONITORING_CHANNEL }}'
 #          slack-message: "Our <${{ env.INVITE_LINK }}|public invite link> was configured to allow signups only from a list of allowed domains:\n1. Go to <https://label-studio.slack.com/admin/settings|Workspace settings>, next to `Joining This Workspace`, click `Expand`.\n2. Delete all domains from the list, select `Allow invitations` and click `Save`."

--- a/.github/workflows/invite-check.yml
+++ b/.github/workflows/invite-check.yml
@@ -18,7 +18,7 @@ jobs:
           ! grep --only-matching --extended-regexp '(&quot;|")isSharedInviteError(&quot;|")\s*:\s*true' <(curl --silent --location --user-agent Chrome/65536.0.0.0 ${{ env.INVITE_LINK }})
       - name: Notify to Slack
         if: always() && steps.invite_link_is_active.outcome == 'failure'
-        uses: slackapi/slack-github-action@v1.26
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e
         with:
           channel-id: '${{ secrets.SLACK_LS_MONITORING_CHANNEL }}'
           slack-message: "Our <${{ env.INVITE_LINK }}|public invite link> has expired and needs to be manually updated:\n1. <https://slack.com/intl/en-es/help/articles/201330256-Invite-new-members-to-your-workspace#share-an-invite-link|Generate a new link> without expiry date; you may need to deactivate the previous one first.\n2. Update the permanent redirect link <https://s3.console.aws.amazon.com/s3/bucket/slack.labelstud.io/property/website/edit?region=us-east-1|on the S3 dashboard> with newly generated link WITHOUT URL SCHEME."
@@ -36,7 +36,7 @@ jobs:
 #          )
 #      - name: Notify to Slack
 #        if: always() && steps.invite_link_has_teamdomains.outcome == 'failure'
-#        uses: slackapi/slack-github-action@v1.26
+#        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e
 #        with:
 #          channel-id: '${{ secrets.SLACK_LS_MONITORING_CHANNEL }}'
 #          slack-message: "Our <${{ env.INVITE_LINK }}|public invite link> was configured to allow signups only from a list of allowed domains:\n1. Go to <https://label-studio.slack.com/admin/settings|Workspace settings>, next to `Joining This Workspace`, click `Expand`.\n2. Delete all domains from the list, select `Allow invitations` and click `Save`."

--- a/.github/workflows/jira-command.yml
+++ b/.github/workflows/jira-command.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Add Workflow link to command comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # Pinned to release v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -64,7 +64,7 @@ jobs:
           type: ${{ github.event.client_payload.slash_command.args.unnamed.arg2 || 'task' }}
 
       - name: Add reaction to command comment on success
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # Pinned to release v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -74,7 +74,7 @@ jobs:
           reactions: "+1"
 
       - name: Add reaction to command comment on failure
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # Pinned to release v4
         if: failure()
         with:
           token: ${{ secrets.GIT_PAT }}
@@ -91,7 +91,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Update comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # Pinned to release v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/jira-command.yml
+++ b/.github/workflows/jira-command.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Add Workflow link to command comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -64,7 +64,7 @@ jobs:
           type: ${{ github.event.client_payload.slash_command.args.unnamed.arg2 || 'task' }}
 
       - name: Add reaction to command comment on success
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -74,7 +74,7 @@ jobs:
           reactions: "+1"
 
       - name: Add reaction to command comment on failure
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         if: failure()
         with:
           token: ${{ secrets.GIT_PAT }}
@@ -91,7 +91,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Update comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/jira-command.yml
+++ b/.github/workflows/jira-command.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Add Workflow link to command comment
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -64,7 +64,7 @@ jobs:
           type: ${{ github.event.client_payload.slash_command.args.unnamed.arg2 || 'task' }}
 
       - name: Add reaction to command comment on success
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -74,7 +74,7 @@ jobs:
           reactions: "+1"
 
       - name: Add reaction to command comment on failure
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        uses: peter-evans/create-or-update-comment@v4
         if: failure()
         with:
           token: ${{ secrets.GIT_PAT }}
@@ -91,7 +91,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Update comment
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GIT_PAT }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/release-cut-off-release-branch.yml
+++ b/.github/workflows/release-cut-off-release-branch.yml
@@ -25,7 +25,7 @@ jobs:
       release_version: ${{ steps.calculate_branch_name_and_version.outputs.release_version }}
       release_branch: ${{ steps.calculate_branch_name_and_version.outputs.release_branch }}
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release-cut-off-release-branch.yml
+++ b/.github/workflows/release-cut-off-release-branch.yml
@@ -25,7 +25,7 @@ jobs:
       release_version: ${{ steps.calculate_branch_name_and_version.outputs.release_version }}
       release_branch: ${{ steps.calculate_branch_name_and_version.outputs.release_branch }}
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release-cut-off-release-branch.yml
+++ b/.github/workflows/release-cut-off-release-branch.yml
@@ -25,7 +25,7 @@ jobs:
       release_version: ${{ steps.calculate_branch_name_and_version.outputs.release_version }}
       release_branch: ${{ steps.calculate_branch_name_and_version.outputs.release_branch }}
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -49,7 +49,7 @@ jobs:
       - promote_docker_image
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Checkout Actions Hub
         uses: actions/checkout@v4
@@ -86,7 +86,7 @@ jobs:
     needs:
       - build-pypi
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Delete Release Candidate Assets
         uses: actions/github-script@v7
@@ -121,7 +121,7 @@ jobs:
     needs:
       - build-pypi
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: DispatchEvent
         uses: actions/github-script@v7
@@ -165,7 +165,7 @@ jobs:
     steps:
       - name: Send Notification to Slack
         id: slack_notify_ops_release
-        uses: slackapi/slack-github-action@v1.26
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e
         with:
           channel-id: '${{ vars.SLACK_CH_RELEASE_TRAIN }}'
           slack-message: |

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -49,7 +49,7 @@ jobs:
       - promote_docker_image
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Checkout Actions Hub
         uses: actions/checkout@v4
@@ -86,7 +86,7 @@ jobs:
     needs:
       - build-pypi
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Delete Release Candidate Assets
         uses: actions/github-script@v7
@@ -121,7 +121,7 @@ jobs:
     needs:
       - build-pypi
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: DispatchEvent
         uses: actions/github-script@v7
@@ -165,7 +165,7 @@ jobs:
     steps:
       - name: Send Notification to Slack
         id: slack_notify_ops_release
-        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e
+        uses: slackapi/slack-github-action@v1.26
         with:
           channel-id: '${{ vars.SLACK_CH_RELEASE_TRAIN }}'
           slack-message: |

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -49,7 +49,7 @@ jobs:
       - promote_docker_image
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Checkout Actions Hub
         uses: actions/checkout@v4
@@ -86,7 +86,7 @@ jobs:
     needs:
       - build-pypi
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Delete Release Candidate Assets
         uses: actions/github-script@v7
@@ -121,7 +121,7 @@ jobs:
     needs:
       - build-pypi
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: DispatchEvent
         uses: actions/github-script@v7
@@ -165,7 +165,7 @@ jobs:
     steps:
       - name: Send Notification to Slack
         id: slack_notify_ops_release
-        uses: slackapi/slack-github-action@v1.26
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e  # Pinned to release v1.26
         with:
           channel-id: '${{ vars.SLACK_CH_RELEASE_TRAIN }}'
           slack-message: |

--- a/.github/workflows/release-set-version.yml
+++ b/.github/workflows/release-set-version.yml
@@ -30,7 +30,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release-set-version.yml
+++ b/.github/workflows/release-set-version.yml
@@ -30,7 +30,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release-set-version.yml
+++ b/.github/workflows/release-set-version.yml
@@ -30,7 +30,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -22,6 +22,6 @@ jobs:
         with:
           python-version: '3.10'
 
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd
+      - uses: pre-commit/action@v3.0.1
         with:
           extra_args: ruff --all-files --hook-stage pre-push

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -22,6 +22,6 @@ jobs:
         with:
           python-version: '3.10'
 
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd
         with:
           extra_args: ruff --all-files --hook-stage pre-push

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -22,6 +22,6 @@ jobs:
         with:
           python-version: '3.10'
 
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # Pinned to release v3.0.1
         with:
           extra_args: ruff --all-files --hook-stage pre-push

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -22,10 +22,10 @@ jobs:
     timeout-minutes: 1
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: "React to comment"
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # Pinned to release v4
         with:
           token: ${{ secrets.GIT_PAT }}
           comment-id: ${{ github.event.comment.id }}
@@ -49,7 +49,7 @@ jobs:
       - name: "Slash Command Dispatch"
         id: scd_issues
         if: steps.determine_command.outputs.command-state == 'known'
-        uses: peter-evans/slash-command-dispatch@v4
+        uses: peter-evans/slash-command-dispatch@13bc09769d122a64f75aa5037256f6f2d78be8c4  # Pinned to release v4
         with:
           token: ${{ secrets.GIT_PAT }}
           reaction-token: ${{ secrets.GIT_PAT }}
@@ -59,7 +59,7 @@ jobs:
 
       - name: "Edit comment with error message"
         if: steps.determine_command.outputs.command-state != 'known'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # Pinned to release v4
         with:
           token: ${{ secrets.GIT_PAT }}
           comment-id: ${{ github.event.comment.id }}

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -22,10 +22,10 @@ jobs:
     timeout-minutes: 1
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: "React to comment"
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GIT_PAT }}
           comment-id: ${{ github.event.comment.id }}
@@ -49,7 +49,7 @@ jobs:
       - name: "Slash Command Dispatch"
         id: scd_issues
         if: steps.determine_command.outputs.command-state == 'known'
-        uses: peter-evans/slash-command-dispatch@13bc09769d122a64f75aa5037256f6f2d78be8c4
+        uses: peter-evans/slash-command-dispatch@v4
         with:
           token: ${{ secrets.GIT_PAT }}
           reaction-token: ${{ secrets.GIT_PAT }}
@@ -59,7 +59,7 @@ jobs:
 
       - name: "Edit comment with error message"
         if: steps.determine_command.outputs.command-state != 'known'
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+        uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GIT_PAT }}
           comment-id: ${{ github.event.comment.id }}

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -22,10 +22,10 @@ jobs:
     timeout-minutes: 1
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: "React to comment"
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           token: ${{ secrets.GIT_PAT }}
           comment-id: ${{ github.event.comment.id }}
@@ -49,7 +49,7 @@ jobs:
       - name: "Slash Command Dispatch"
         id: scd_issues
         if: steps.determine_command.outputs.command-state == 'known'
-        uses: peter-evans/slash-command-dispatch@v4
+        uses: peter-evans/slash-command-dispatch@13bc09769d122a64f75aa5037256f6f2d78be8c4
         with:
           token: ${{ secrets.GIT_PAT }}
           reaction-token: ${{ secrets.GIT_PAT }}
@@ -59,7 +59,7 @@ jobs:
 
       - name: "Edit comment with error message"
         if: steps.determine_command.outputs.command-state != 'known'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           token: ${{ secrets.GIT_PAT }}
           comment-id: ${{ github.event.comment.id }}

--- a/.github/workflows/submodules-validator.yml
+++ b/.github/workflows/submodules-validator.yml
@@ -23,7 +23,7 @@ jobs:
     name: "Submodules/deps"
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Validate
         uses: actions/github-script@v7

--- a/.github/workflows/submodules-validator.yml
+++ b/.github/workflows/submodules-validator.yml
@@ -23,7 +23,7 @@ jobs:
     name: "Submodules/deps"
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Validate
         uses: actions/github-script@v7

--- a/.github/workflows/submodules-validator.yml
+++ b/.github/workflows/submodules-validator.yml
@@ -23,7 +23,7 @@ jobs:
     name: "Submodules/deps"
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Validate
         uses: actions/github-script@v7

--- a/.github/workflows/test_conda.yml
+++ b/.github/workflows/test_conda.yml
@@ -31,7 +31,7 @@ jobs:
         shell: bash
 
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -40,14 +40,14 @@ jobs:
           ref: ${{ inputs.head_sha }}
 
       - name: Setup Conda
-        uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca
+        uses: conda-incubator/setup-miniconda@v3.0.4
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
           activate-environment: test-environment
 
       - name: Set up Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a
+        uses: snok/install-poetry@v1
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/test_conda.yml
+++ b/.github/workflows/test_conda.yml
@@ -31,7 +31,7 @@ jobs:
         shell: bash
 
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -40,14 +40,14 @@ jobs:
           ref: ${{ inputs.head_sha }}
 
       - name: Setup Conda
-        uses: conda-incubator/setup-miniconda@v3.0.4
+        uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca  # Pinned to release v3.0.4
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
           activate-environment: test-environment
 
       - name: Set up Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a  # Pinned to release v1
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/test_conda.yml
+++ b/.github/workflows/test_conda.yml
@@ -31,7 +31,7 @@ jobs:
         shell: bash
 
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -40,14 +40,14 @@ jobs:
           ref: ${{ inputs.head_sha }}
 
       - name: Setup Conda
-        uses: conda-incubator/setup-miniconda@v3.0.4
+        uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
           activate-environment: test-environment
 
       - name: Set up Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/test_migrations.yml
+++ b/.github/workflows/test_migrations.yml
@@ -26,7 +26,7 @@ jobs:
       # SENTRY_DSN:
 
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
           sudo apt-get install libsasl2-dev python3-dev libldap2-dev libssl-dev libxml2-dev libxslt-dev
 
       - name: Set up Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a  # Pinned to release v1
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/test_migrations.yml
+++ b/.github/workflows/test_migrations.yml
@@ -26,7 +26,7 @@ jobs:
       # SENTRY_DSN:
 
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
           sudo apt-get install libsasl2-dev python3-dev libldap2-dev libssl-dev libxml2-dev libxslt-dev
 
       - name: Set up Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a
+        uses: snok/install-poetry@v1
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/test_migrations.yml
+++ b/.github/workflows/test_migrations.yml
@@ -26,7 +26,7 @@ jobs:
       # SENTRY_DSN:
 
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
           sudo apt-get install libsasl2-dev python3-dev libldap2-dev libssl-dev libxml2-dev libxslt-dev
 
       - name: Set up Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/tests-yarn-e2e.yml
+++ b/.github/workflows/tests-yarn-e2e.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Configure git
         shell: bash

--- a/.github/workflows/tests-yarn-e2e.yml
+++ b/.github/workflows/tests-yarn-e2e.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Configure git
         shell: bash

--- a/.github/workflows/tests-yarn-e2e.yml
+++ b/.github/workflows/tests-yarn-e2e.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Configure git
         shell: bash

--- a/.github/workflows/tests-yarn-integration.yml
+++ b/.github/workflows/tests-yarn-integration.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Configure git
         shell: bash

--- a/.github/workflows/tests-yarn-integration.yml
+++ b/.github/workflows/tests-yarn-integration.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Configure git
         shell: bash

--- a/.github/workflows/tests-yarn-integration.yml
+++ b/.github/workflows/tests-yarn-integration.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Configure git
         shell: bash

--- a/.github/workflows/tests-yarn-unit.yml
+++ b/.github/workflows/tests-yarn-unit.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Configure git
         shell: bash

--- a/.github/workflows/tests-yarn-unit.yml
+++ b/.github/workflows/tests-yarn-unit.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Configure git
         shell: bash

--- a/.github/workflows/tests-yarn-unit.yml
+++ b/.github/workflows/tests-yarn-unit.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Configure git
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       # SENTRY_DSN:
 
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
           sudo apt-get install libffi7 libldap2-dev libsasl2-dev libssl-dev libxml2-dev libxslt-dev python3-dev
 
       - name: Set up Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a
 
       - name: Install Python dependencies
         run: poetry install --with test
@@ -122,7 +122,7 @@ jobs:
           - 6379:6379
 
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -141,7 +141,7 @@ jobs:
           sudo apt-get install libffi7 libldap2-dev libsasl2-dev libssl-dev libxml2-dev libxslt-dev python3-dev
 
       - name: Set up Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a
 
       - name: Install Python dependencies
         run: poetry install --with test
@@ -160,7 +160,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login != 'dependabot[bot]' }}
-        uses: codecov/codecov-action@v4.5.0
+        uses: codecov/codecov-action@79066c46f8dcdf8d7355f820dbac958c5b4cb9d3
         with:
           name: codecov-python-${{ matrix.python-version }}
           flags: pytests
@@ -199,7 +199,7 @@ jobs:
       # SENTRY_DSN:
 
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -213,7 +213,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a
 
       - name: Install Python dependencies
         run: poetry install --with test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       # SENTRY_DSN:
 
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
           sudo apt-get install libffi7 libldap2-dev libsasl2-dev libssl-dev libxml2-dev libxslt-dev python3-dev
 
       - name: Set up Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a  # Pinned to release v1
 
       - name: Install Python dependencies
         run: poetry install --with test
@@ -122,7 +122,7 @@ jobs:
           - 6379:6379
 
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -141,7 +141,7 @@ jobs:
           sudo apt-get install libffi7 libldap2-dev libsasl2-dev libssl-dev libxml2-dev libxslt-dev python3-dev
 
       - name: Set up Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a  # Pinned to release v1
 
       - name: Install Python dependencies
         run: poetry install --with test
@@ -160,7 +160,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login != 'dependabot[bot]' }}
-        uses: codecov/codecov-action@v4.5.0
+        uses: codecov/codecov-action@79066c46f8dcdf8d7355f820dbac958c5b4cb9d3  # Pinned to release v4.5.0
         with:
           name: codecov-python-${{ matrix.python-version }}
           flags: pytests
@@ -199,7 +199,7 @@ jobs:
       # SENTRY_DSN:
 
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -213,7 +213,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a  # Pinned to release v1
 
       - name: Install Python dependencies
         run: poetry install --with test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       # SENTRY_DSN:
 
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
           sudo apt-get install libffi7 libldap2-dev libsasl2-dev libssl-dev libxml2-dev libxslt-dev python3-dev
 
       - name: Set up Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a
+        uses: snok/install-poetry@v1
 
       - name: Install Python dependencies
         run: poetry install --with test
@@ -122,7 +122,7 @@ jobs:
           - 6379:6379
 
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -141,7 +141,7 @@ jobs:
           sudo apt-get install libffi7 libldap2-dev libsasl2-dev libssl-dev libxml2-dev libxslt-dev python3-dev
 
       - name: Set up Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a
+        uses: snok/install-poetry@v1
 
       - name: Install Python dependencies
         run: poetry install --with test
@@ -160,7 +160,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login != 'dependabot[bot]' }}
-        uses: codecov/codecov-action@79066c46f8dcdf8d7355f820dbac958c5b4cb9d3
+        uses: codecov/codecov-action@v4.5.0
         with:
           name: codecov-python-${{ matrix.python-version }}
           flags: pytests
@@ -199,7 +199,7 @@ jobs:
       # SENTRY_DSN:
 
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -213,7 +213,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a
+        uses: snok/install-poetry@v1
 
       - name: Install Python dependencies
         run: poetry install --with test

--- a/.github/workflows/update_pip_dependancy.yml
+++ b/.github/workflows/update_pip_dependancy.yml
@@ -13,7 +13,7 @@ jobs:
     name: Sync PR
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,7 +29,7 @@ jobs:
           git config --global user.email 'robot-ci-heartex@users.noreply.github.com'
 
       - name: Set up Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a
 
       - name: Commit version files to 'develop'
         id: make-develop-commit

--- a/.github/workflows/update_pip_dependancy.yml
+++ b/.github/workflows/update_pip_dependancy.yml
@@ -13,7 +13,7 @@ jobs:
     name: Sync PR
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,7 +29,7 @@ jobs:
           git config --global user.email 'robot-ci-heartex@users.noreply.github.com'
 
       - name: Set up Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a  # Pinned to release v1
 
       - name: Commit version files to 'develop'
         id: make-develop-commit

--- a/.github/workflows/update_pip_dependancy.yml
+++ b/.github/workflows/update_pip_dependancy.yml
@@ -13,7 +13,7 @@ jobs:
     name: Sync PR
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,7 +29,7 @@ jobs:
           git config --global user.email 'robot-ci-heartex@users.noreply.github.com'
 
       - name: Set up Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a
+        uses: snok/install-poetry@v1
 
       - name: Commit version files to 'develop'
         id: make-develop-commit

--- a/.github/workflows/validator-pull-request-labeler.yml
+++ b/.github/workflows/validator-pull-request-labeler.yml
@@ -26,17 +26,17 @@ jobs:
       pull-requests: write
     steps:
 
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820  # Pinned to release v3.0.0
 
       - name: "Validate PR's title"
-        uses: thehanimo/pr-title-checker@v1.4.2
+        uses: thehanimo/pr-title-checker@1d8cd483a2b73118406a187f54dca8a9415f1375  # Pinned to release v1.4.2
         with:
           GITHUB_TOKEN: ${{ github.token }}
           pass_on_octokit_error: false
           configuration_path: ".github/pr-title-checker-config.json"
 
       - name: "Set PR's label based on title"
-        uses: release-drafter/release-drafter@v6.0.0
+        uses: release-drafter/release-drafter@805574fd5375e6902a5875239fb834f515c41111  # Pinned to release v6.0.0
         with:
           disable-releaser: true
           config-name: autolabeler.yml

--- a/.github/workflows/validator-pull-request-labeler.yml
+++ b/.github/workflows/validator-pull-request-labeler.yml
@@ -26,17 +26,17 @@ jobs:
       pull-requests: write
     steps:
 
-      - uses: hmarr/debug-action@v3.0.0
+      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
 
       - name: "Validate PR's title"
-        uses: thehanimo/pr-title-checker@v1.4.2
+        uses: thehanimo/pr-title-checker@1d8cd483a2b73118406a187f54dca8a9415f1375
         with:
           GITHUB_TOKEN: ${{ github.token }}
           pass_on_octokit_error: false
           configuration_path: ".github/pr-title-checker-config.json"
 
       - name: "Set PR's label based on title"
-        uses: release-drafter/release-drafter@v6.0.0
+        uses: release-drafter/release-drafter@805574fd5375e6902a5875239fb834f515c41111
         with:
           disable-releaser: true
           config-name: autolabeler.yml

--- a/.github/workflows/validator-pull-request-labeler.yml
+++ b/.github/workflows/validator-pull-request-labeler.yml
@@ -26,17 +26,17 @@ jobs:
       pull-requests: write
     steps:
 
-      - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+      - uses: hmarr/debug-action@v3.0.0
 
       - name: "Validate PR's title"
-        uses: thehanimo/pr-title-checker@1d8cd483a2b73118406a187f54dca8a9415f1375
+        uses: thehanimo/pr-title-checker@v1.4.2
         with:
           GITHUB_TOKEN: ${{ github.token }}
           pass_on_octokit_error: false
           configuration_path: ".github/pr-title-checker-config.json"
 
       - name: "Set PR's label based on title"
-        uses: release-drafter/release-drafter@805574fd5375e6902a5875239fb834f515c41111
+        uses: release-drafter/release-drafter@v6.0.0
         with:
           disable-releaser: true
           config-name: autolabeler.yml


### PR DESCRIPTION
Out of an abundance of caution, we are pinning these third-party actions to specific commits in order to enhance security.

See https://www.stepsecurity.io/blog/pinning-github-actions-for-enhanced-security-a-complete-guide for a discussion for why this is a good idea.