### PR TITLE
rebasable hosting

### DIFF
--- a/deploy/uwsgi.ini
+++ b/deploy/uwsgi.ini
@@ -1,7 +1,13 @@
 [uwsgi]
 chdir = /label-studio/label_studio
 http = :8000
+if-env = LABEL_STUDIO_URL_BASE
+mount = /$(LABEL_STUDIO_URL_BASE)=core.wsgi:application
+manage-script-name = true
+endif =
+if-not-env = LABEL_STUDIO_URL_BASE
 module = core.wsgi:application
+endif =
 master = true
 cheaper = true
 single-interpreter = true

--- a/label_studio/core/settings/base.py
+++ b/label_studio/core/settings/base.py
@@ -19,6 +19,8 @@ from django.core.exceptions import ImproperlyConfigured
 
 from label_studio.core.utils.params import get_bool_env, get_env_list
 
+logging.getLogger('faker').setLevel(logging.ERROR)
+
 formatter = 'standard'
 JSON_LOG = get_bool_env('JSON_LOG', False)
 if JSON_LOG:
@@ -394,7 +396,7 @@ USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.1/howto/static-files/
-STATIC_URL = '/static/'
+STATIC_URL = get_env( 'STATIC_PATH', '/static/' )
 # if FORCE_SCRIPT_NAME:
 #    STATIC_URL = FORCE_SCRIPT_NAME + STATIC_URL
 logger.info(f'=> Static URL is set to: {STATIC_URL}')

--- a/label_studio/server.py
+++ b/label_studio/server.py
@@ -9,6 +9,10 @@ import pathlib
 import socket
 import sys
 
+import faker
+
+logging.getLogger('faker').setLevel(logging.ERROR)
+
 from colorama import Fore, init
 
 if sys.platform == 'win32':


### PR DESCRIPTION
allow label studio to properly host on a subpath without external rewriting.

to use it, set:
LABEL_STUDIO_HOST="http://host:port/subpath"
LABEL_STUDIO_STATIC_PATH="/subpath/static"
LABEL_STUDIO_URL_BASE="/subpath

